### PR TITLE
Scope Firebase query to esp32-01 stream

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -70,7 +70,11 @@ function App() {
   const [customRange, setCustomRange] = useState(null);
 
   useEffect(() => {
-    const readingsQuery = query(ref(database), orderByChild('ts'), limitToLast(720));
+    const readingsQuery = query(
+      ref(database, 'streams/esp32-01'),
+      orderByChild('ts'),
+      limitToLast(720),
+    );
 
     const unsubscribe = onValue(
       readingsQuery,


### PR DESCRIPTION
## Summary
- scope the Firebase readings query to the streams/esp32-01 node while keeping ordering and limits

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0dae0e468832ba9446fa47fdd6bcc